### PR TITLE
Changed module name to project-machine/qcli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/raharper/qcli
+module github.com/project-machine/qcli
 
 go 1.19
 


### PR DESCRIPTION
Using github.com/project-machine/qcli instead of github.com/raharper/qcli as module name in go.mod