### PR TITLE
feat: add support for vvfat blockdev

### DIFF
--- a/device.go
+++ b/device.go
@@ -119,6 +119,9 @@ const (
 	//VhostUserFS represents a virtio-fs vhostuser device type
 	VhostUserFS DeviceDriver = "vhost-user-fs"
 
+	//VVFAT represents a virtual VFAT block device
+	VVFAT DeviceDriver = "vvfat"
+
 	// PCIBridgeDriver represents a PCI bridge device type.
 	PCIBridgeDriver DeviceDriver = "pci-bridge"
 


### PR DESCRIPTION
QEMU's vvfat driver can export a directory as a VFAT filsystem into the guest.  In particular, we'd like to be able to set the volume label so that cloud-init can detect the fs as cloud-config.  The qemu -drive cli doesn't expose the label property but it is available via the -blockdev command.  Here we special case VVFAT in blockdev until an overhaul is done converting all -drive use into -blockdev.